### PR TITLE
chore: update repository link for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "author": "",
   "homepage": "",
   "license": "MIT",
-  "repository": "https://github.com/kitze/react-conditional-wrap",
+  "repository": "https://github.com/kitze/conditional-wrap",
   "keywords": [
     "react-component"
   ]


### PR DESCRIPTION
Currently the npm package has no link to the github repository, so I had to go hunting a bit.