### PR TITLE
Fix ref forwarding

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,4 @@
-export default ({ condition, wrap, children }) => (condition ? wrap(children) : children);
+import React from 'react';
+
+export default ({ condition, children, wrap }) =>
+  condition ? React.cloneElement(wrap(children)) : children;


### PR DESCRIPTION
The old version loses refs and a lot of libraries rely on refs (e.g. `@tippyjs/react`). I wrapped it with cloneElement to preserve refs