### PR TITLE
fix: widen type of children and wrapping component

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="react" />
 interface ConditionalWrapProps {
   condition: boolean;
-  wrap: (children: JSX.Element) => JSX.Element;
-  children: JSX.Element;
+  wrap: (children: React.ReactNode) => React.ReactNode;
+  children: React.ReactNode;
 }
-declare const _default: ({ condition, children, wrap }: ConditionalWrapProps) => JSX.Element;
+declare const _default: ({ condition, children, wrap }: ConditionalWrapProps) => React.ReactNode;
 export default _default;


### PR DESCRIPTION
Replaces `JSX.Element` with `React.ReactNode`.

See https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/09ff8a1d460fdd657aaa97bb8b1deac9e66dc1ea/README.md#useful-react-prop-type-examples

My specific use-case is as follows, where `children` could be an array of elements or nonexistent. `JSX.Element` is too narrow to handle those cases.

```jsx
<ConditionalWrap
  condition={myCondition}
  wrap={(children) => (
    <SomeComponent>
      {children}
    </SomeComponent>
  )}
>
  {children}
</ConditionalWrap>
```